### PR TITLE
Wal-536: update database env vars

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,12 @@ pipeline:
       - pytest -v
 
     environment:
-      - DATABASE_ENGINE=postgresql://root:root@postgres:5432/db
+      DATABASE_ENGINE: "postgresql"
+      DATABASE_NAME: "blueprint_flask_service"
+      DATABASE_USER: "root"
+      DATABASE_PASSWORD: "root"
+      DATABASE_HOST: "postgres_blueprint_flask_service"
+      DATABASE_PORT: "5432"
     when:
       event: [pull_request, push, tag]
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,9 @@ Run a web server with this service:
 docker-compose up
 ```
 
-Now, open your browser and go to [http://localhost:8080](http://localhost:8080).
+Now, open your browser and go to [http://localhost:8089](http://localhost:8089).
 
-For the admin panel, go to [http://localhost:8080/admin](http://localhost:8080/admin)
-(user: `admin`, password: `admin`).
+For the Swagger API Doc, go to [http://localhost:8089/docs](http://localhost:8089/docs).
 
 ### Run tests
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,14 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     DEBUG = False
-    SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
+    DATABASE_ENGINE = os.environ.get('DATABASE_ENGINE', 'postgresql')
+    DATABASE_HOST = os.environ.get('DATABASE_HOST', 'localhost')
+    DATABASE_PORT = os.environ.get('DATABASE_PORT', '5432')
+    DATABASE_NAME = os.environ['DATABASE_NAME']
+    DATABASE_USER = os.environ['DATABASE_USER']
+    DATABASE_PASSWORD = os.environ.get('DATABASE_PASSWORD', '')
+    SQLALCHEMY_DATABASE_URI = (f'{DATABASE_ENGINE}://{DATABASE_USER}:{DATABASE_PASSWORD}@'
+                               f'{DATABASE_HOST}:{DATABASE_PORT}/{DATABASE_NAME}')
 
 
 class DevelopmentConfig(Config):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,12 @@ services:
     depends_on:
       - postgres_blueprint_flask_service
     environment:
-      DATABASE_URL: "postgresql://root:root@postgres_blueprint_flask_service:5432/blueprint_flask_service"
+      DATABASE_ENGINE: "postgresql"
+      DATABASE_NAME: "blueprint_flask_service"
+      DATABASE_USER: "root"
+      DATABASE_PASSWORD: "root"
+      DATABASE_HOST: "postgres_blueprint_flask_service"
+      DATABASE_PORT: "5432"
       JWT_PUBLIC_KEY_RSA_BIFROST: |-
         -----BEGIN PUBLIC KEY-----
         MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALFc9NFZaOaSwUMPNektbtJqEjYZ6IRB


### PR DESCRIPTION
## Purpose
We need to have separated db env variables with specific names to run this blueprint in Walhall.